### PR TITLE
Makefile: install compatibility with OSX/BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,11 @@ cd-discid: $(OBJS)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(OBJS)
 
 install: cd-discid
-	$(INSTALL) -D cd-discid $(DESTDIR)$(BINDIR)/cd-discid
+	mkdir -p $(BINDIR)
+	mkdir -p $(MANDIR)
+	$(INSTALL) cd-discid $(DESTDIR)$(BINDIR)/cd-discid
 	$(STRIP) $(DESTDIR)$(BINDIR)/cd-discid
-	$(INSTALL) -D -m 644 cd-discid.1 $(DESTDIR)$(MANDIR)/cd-discid.1
+	$(INSTALL) -m 644 cd-discid.1 $(DESTDIR)$(MANDIR)/cd-discid.1
 
 clean:
 	$(RM) $(OBJS) cd-discid


### PR DESCRIPTION
The `-D` option is not available in the BSD version of `install`.